### PR TITLE
Fix Slice.DeleteAt() memory corruption bug

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -91,7 +91,10 @@ func (a Slice[T]) Delete(element T) Slice[T] {
 
 // DeleteAt will delete an element by index
 func (a Slice[T]) DeleteAt(index int) Slice[T] {
-	return append(a[:index], a[index+1:]...)
+	result := make(Slice[T], 0, len(a)-1)
+	result = append(result, a[:index]...)
+	result = append(result, a[index+1:]...)
+	return result
 }
 
 // DeleteIf will delete all elements which "block" returns true for

--- a/slice_test.go
+++ b/slice_test.go
@@ -156,6 +156,20 @@ func TestSliceDeleteAt(t *testing.T) {
 	AssertSlicesEquals(t, result, a)
 }
 
+func TestSliceDeleteAtNoMutation(t *testing.T) {
+	// Test that DeleteAt doesn't mutate the original slice
+	original := Slice[int]{1, 2, 3, 4, 5}
+	originalCopy := Slice[int]{1, 2, 3, 4, 5}
+	result := original.DeleteAt(2)
+
+	// Verify the result is correct
+	expected := Slice[int]{1, 2, 4, 5}
+	AssertSlicesEquals(t, expected, result)
+
+	// Verify original slice is unchanged
+	AssertSlicesEquals(t, originalCopy, original)
+}
+
 func TestSliceDeleteIf(t *testing.T) {
 	a := Slice[int]{1, 2, 3, 4, 5, 6}
 	a = a.DeleteIf(func(e int) bool {


### PR DESCRIPTION
The previous implementation modified the underlying array of the original slice, causing unexpected mutations. This fix creates a new slice and copies elements to prevent any modifications to the original.

Added TestSliceDeleteAtNoMutation to verify the original slice remains unchanged after calling DeleteAt().

Fixes: Memory corruption in Slice.DeleteAt() (#1 in BUG_REPORT.md)