### PR TITLE
Fix Slice.Partition() O(n²) performance bug

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -392,9 +392,9 @@ func (s Slice[T]) Partition(predicate func(T) bool) (Slice[T], Slice[T]) {
 
 	for _, item := range s {
 		if predicate(item) {
-			trueSet = trueSet.Push(item)
+			trueSet = append(trueSet, item)
 		} else {
-			falseSet = falseSet.Push(item)
+			falseSet = append(falseSet, item)
 		}
 	}
 

--- a/slice_test.go
+++ b/slice_test.go
@@ -597,3 +597,17 @@ func TestSlice_Partition(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkSlicePartition(b *testing.B) {
+	// Create a large slice to test performance
+	size := 1000
+	s := make(Slice[int], size)
+	for i := 0; i < size; i++ {
+		s[i] = i
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.Partition(func(n int) bool { return n%2 == 0 })
+	}
+}


### PR DESCRIPTION
The previous implementation used Push() in a loop, creating a new slice on each iteration, resulting in O(n²) time complexity. This fix uses append() directly for O(n) performance.

Before: trueSet = trueSet.Push(item)  // Creates new slice each time
After:  trueSet = append(trueSet, item)  // Efficient append

Added BenchmarkSlicePartition to measure performance.

Fixes: O(n²) performance in Slice.Partition() (#2 in BUG_REPORT.md)