### PR TITLE
Fix Set.Each() incorrect documentation

### DIFF
--- a/set.go
+++ b/set.go
@@ -153,8 +153,7 @@ func (s *Set[T]) Equal(other *Set[T]) bool {
 	return s.Size() == other.Size() && s.IsSubset(other)
 }
 
-// Each iterates over all elements in the set and calls the provided function for each element.
-// The order of iteration is not guaranteed.
+// Each iterates over all elements in the set in insertion order and calls the provided function for each element.
 func (s *Set[T]) Each(fn func(T)) {
 	for _, item := range s.order {
 		fn(item)

--- a/set_test.go
+++ b/set_test.go
@@ -836,6 +836,22 @@ func TestSet_Each(t *testing.T) {
 	}
 }
 
+func TestSet_EachOrderPreserved(t *testing.T) {
+	// Test that Each iterates in insertion order
+	set := NewSet(5, 2, 8, 1, 9, 3)
+
+	var result []int
+	set.Each(func(item int) {
+		result = append(result, item)
+	})
+
+	// Verify elements are in insertion order
+	expected := []int{5, 2, 8, 1, 9, 3}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Each() did not preserve insertion order. Got %v, want %v", result, expected)
+	}
+}
+
 func TestSetMap(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Updated documentation to accurately reflect that Each() iterates in insertion order, not in an unordered manner.

Before: "The order of iteration is not guaranteed"
After: "Each iterates over all elements in the set in insertion order"

Added TestSet_EachOrderPreserved to verify and document that iteration order matches insertion order.

Fixes: Incorrect documentation in Set.Each() (#12 in BUG_REPORT.md)