### PR TITLE
Fix Slice.DeleteAt to handle out-of-bounds indices gracefully

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -90,7 +90,11 @@ func (a Slice[T]) Delete(element T) Slice[T] {
 }
 
 // DeleteAt will delete an element by index
+// If index is out of bounds (negative or >= length), returns original slice unchanged
 func (a Slice[T]) DeleteAt(index int) Slice[T] {
+	if index < 0 || index >= len(a) {
+		return a
+	}
 	result := make(Slice[T], 0, len(a)-1)
 	result = append(result, a[:index]...)
 	result = append(result, a[index+1:]...)

--- a/slice_test.go
+++ b/slice_test.go
@@ -787,3 +787,74 @@ func BenchmarkSlicePartition(b *testing.B) {
 		s.Partition(func(n int) bool { return n%2 == 0 })
 	}
 }
+
+func TestSliceDeleteAtBoundsCheck(t *testing.T) {
+	tests := []struct {
+		name     string
+		slice    Slice[int]
+		index    int
+		expected Slice[int]
+	}{
+		{
+			name:     "negative index",
+			slice:    Slice[int]{1, 2, 3, 4},
+			index:    -1,
+			expected: Slice[int]{1, 2, 3, 4},
+		},
+		{
+			name:     "index equals length",
+			slice:    Slice[int]{1, 2, 3, 4},
+			index:    4,
+			expected: Slice[int]{1, 2, 3, 4},
+		},
+		{
+			name:     "index greater than length",
+			slice:    Slice[int]{1, 2, 3, 4},
+			index:    10,
+			expected: Slice[int]{1, 2, 3, 4},
+		},
+		{
+			name:     "empty slice with index 0",
+			slice:    Slice[int]{},
+			index:    0,
+			expected: Slice[int]{},
+		},
+		{
+			name:     "valid index at start",
+			slice:    Slice[int]{1, 2, 3, 4},
+			index:    0,
+			expected: Slice[int]{2, 3, 4},
+		},
+		{
+			name:     "valid index at end",
+			slice:    Slice[int]{1, 2, 3, 4},
+			index:    3,
+			expected: Slice[int]{1, 2, 3},
+		},
+		{
+			name:     "valid index in middle",
+			slice:    Slice[int]{1, 2, 3, 4},
+			index:    1,
+			expected: Slice[int]{1, 3, 4},
+		},
+		{
+			name:     "single element with valid index",
+			slice:    Slice[int]{42},
+			index:    0,
+			expected: Slice[int]{},
+		},
+		{
+			name:     "single element with out of bounds index",
+			slice:    Slice[int]{42},
+			index:    1,
+			expected: Slice[int]{42},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.slice.DeleteAt(tt.index)
+			AssertSlicesEquals(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The `Slice.DeleteAt` method currently panics when given an out-of-bounds index (negative or >= length). This is inconsistent with other methods in the package like `At()` which handle invalid indices gracefully.

## Example of the bug

```go
a := types.Slice[int]{1, 2, 3, 4}
result := a.DeleteAt(10)  // panics: slice bounds out of range
result2 := a.DeleteAt(-1) // panics: slice bounds out of range
```

## Solution

This PR adds bounds checking to `DeleteAt` to return the original slice unchanged when given an invalid index, making it consistent with other methods in the package.

## Changes

- Add bounds check in `DeleteAt` method
- Return original slice for `index < 0` or `index >= len(slice)`
- Add comprehensive test cases covering edge cases:
  * Negative indices
  * Index equal to or greater than length
  * Empty slices
  * Single element slices
  * Valid indices at start, middle, and end

## Testing

All existing tests pass, and new tests have been added to cover the edge cases.