### PR TITLE
Add Find and None methods to Slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ func (a Slice[T]) EachIndex(block func(int))
 func (a Slice[T]) Fetch(index int, defaultValue T) T
 func (a Slice[T]) Fill(element T, start int, length int) Slice[T]
 func (a Slice[T]) FillWith(start int, length int, block func(int) T) Slice[T]
+func (a Slice[T]) Find(predicate func(T) bool) (T, bool)
 func (a Slice[T]) First() *T
 func (a Slice[T]) Firsts(count int) Slice[T]
 func (a Slice[T]) Include(element T) bool
@@ -67,6 +68,7 @@ func (a Slice[T]) Len() int
 func (a Slice[T]) Map(block func(T) T) Slice[T]
 func (a Slice[T]) Max(block func(T) int) T
 func (a Slice[T]) Min(block func(T) int) T
+func (a Slice[T]) None(predicate func(T) bool) bool
 func (a Slice[T]) Partition(predicate func(T) bool) (Slice[T], Slice[T])
 func (a Slice[T]) Pop() (Slice[T], T)
 func (a Slice[T]) Push(element T) Slice[T]

--- a/slice.go
+++ b/slice.go
@@ -78,6 +78,24 @@ func (a Slice[T]) All(block func(T) bool) bool {
 	return true
 }
 
+// None returns true if no elements in the slice satisfy the predicate function.
+// Returns true for empty slices.
+func (a Slice[T]) None(predicate func(T) bool) bool {
+	return !a.Any(predicate)
+}
+
+// Find returns the first element that satisfies the predicate function and true.
+// If no element satisfies the predicate, it returns the zero value of T and false.
+func (a Slice[T]) Find(predicate func(T) bool) (T, bool) {
+	for _, item := range a {
+		if predicate(item) {
+			return item, true
+		}
+	}
+	var zero T
+	return zero, false
+}
+
 // Delete will remove all elements that are equal to the passed element
 func (a Slice[T]) Delete(element T) Slice[T] {
 	result := Slice[T]{}

--- a/slice_find_none_test.go
+++ b/slice_find_none_test.go
@@ -1,0 +1,200 @@
+package types
+
+import "testing"
+
+func TestSliceNone(t *testing.T) {
+	tests := []struct {
+		name      string
+		slice     Slice[int]
+		predicate func(int) bool
+		expected  bool
+	}{
+		{
+			name:      "empty slice",
+			slice:     Slice[int]{},
+			predicate: func(x int) bool { return x > 0 },
+			expected:  true, // None returns true for empty slices
+		},
+		{
+			name:      "no elements satisfy predicate",
+			slice:     Slice[int]{1, 2, 3, 4, 5},
+			predicate: func(x int) bool { return x > 10 },
+			expected:  true,
+		},
+		{
+			name:      "some elements satisfy predicate",
+			slice:     Slice[int]{1, 2, 3, 4, 5},
+			predicate: func(x int) bool { return x == 3 },
+			expected:  false,
+		},
+		{
+			name:      "all elements satisfy predicate",
+			slice:     Slice[int]{2, 4, 6, 8},
+			predicate: func(x int) bool { return x%2 == 0 },
+			expected:  false,
+		},
+		{
+			name:      "single element satisfies",
+			slice:     Slice[int]{5},
+			predicate: func(x int) bool { return x == 5 },
+			expected:  false,
+		},
+		{
+			name:      "single element does not satisfy",
+			slice:     Slice[int]{5},
+			predicate: func(x int) bool { return x == 10 },
+			expected:  true,
+		},
+		{
+			name:      "negative numbers - none negative",
+			slice:     Slice[int]{1, 2, 3, 4},
+			predicate: func(x int) bool { return x < 0 },
+			expected:  true,
+		},
+		{
+			name:      "negative numbers - has negative",
+			slice:     Slice[int]{-1, 2, 3, 4},
+			predicate: func(x int) bool { return x < 0 },
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.slice.None(tt.predicate)
+			if result != tt.expected {
+				t.Errorf("None() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSliceFind(t *testing.T) {
+	tests := []struct {
+		name          string
+		slice         Slice[int]
+		predicate     func(int) bool
+		expectedValue int
+		expectedFound bool
+	}{
+		{
+			name:          "empty slice",
+			slice:         Slice[int]{},
+			predicate:     func(x int) bool { return x > 0 },
+			expectedValue: 0,
+			expectedFound: false,
+		},
+		{
+			name:          "find first even number",
+			slice:         Slice[int]{1, 3, 4, 5, 6},
+			predicate:     func(x int) bool { return x%2 == 0 },
+			expectedValue: 4,
+			expectedFound: true,
+		},
+		{
+			name:          "find first odd number",
+			slice:         Slice[int]{2, 4, 5, 6, 7},
+			predicate:     func(x int) bool { return x%2 != 0 },
+			expectedValue: 5,
+			expectedFound: true,
+		},
+		{
+			name:          "no element satisfies predicate",
+			slice:         Slice[int]{1, 2, 3, 4, 5},
+			predicate:     func(x int) bool { return x > 10 },
+			expectedValue: 0,
+			expectedFound: false,
+		},
+		{
+			name:          "first element satisfies",
+			slice:         Slice[int]{10, 2, 3, 4, 5},
+			predicate:     func(x int) bool { return x > 5 },
+			expectedValue: 10,
+			expectedFound: true,
+		},
+		{
+			name:          "last element satisfies",
+			slice:         Slice[int]{1, 2, 3, 4, 10},
+			predicate:     func(x int) bool { return x > 5 },
+			expectedValue: 10,
+			expectedFound: true,
+		},
+		{
+			name:          "multiple elements satisfy - returns first",
+			slice:         Slice[int]{1, 5, 8, 10, 12},
+			predicate:     func(x int) bool { return x > 4 },
+			expectedValue: 5,
+			expectedFound: true,
+		},
+		{
+			name:          "single element satisfies",
+			slice:         Slice[int]{42},
+			predicate:     func(x int) bool { return x == 42 },
+			expectedValue: 42,
+			expectedFound: true,
+		},
+		{
+			name:          "single element does not satisfy",
+			slice:         Slice[int]{42},
+			predicate:     func(x int) bool { return x == 10 },
+			expectedValue: 0,
+			expectedFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, found := tt.slice.Find(tt.predicate)
+			if found != tt.expectedFound {
+				t.Errorf("Find() found = %v, expected %v", found, tt.expectedFound)
+			}
+			if value != tt.expectedValue {
+				t.Errorf("Find() value = %v, expected %v", value, tt.expectedValue)
+			}
+		})
+	}
+}
+
+func TestSliceFindString(t *testing.T) {
+	tests := []struct {
+		name          string
+		slice         Slice[string]
+		predicate     func(string) bool
+		expectedValue string
+		expectedFound bool
+	}{
+		{
+			name:          "find string starting with 'h'",
+			slice:         Slice[string]{"apple", "banana", "hello", "world"},
+			predicate:     func(s string) bool { return len(s) > 0 && s[0] == 'h' },
+			expectedValue: "hello",
+			expectedFound: true,
+		},
+		{
+			name:          "find string with length > 6",
+			slice:         Slice[string]{"cat", "dog", "elephant", "fox"},
+			predicate:     func(s string) bool { return len(s) > 6 },
+			expectedValue: "elephant",
+			expectedFound: true,
+		},
+		{
+			name:          "no string matches",
+			slice:         Slice[string]{"cat", "dog", "fox"},
+			predicate:     func(s string) bool { return len(s) > 10 },
+			expectedValue: "",
+			expectedFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, found := tt.slice.Find(tt.predicate)
+			if found != tt.expectedFound {
+				t.Errorf("Find() found = %v, expected %v", found, tt.expectedFound)
+			}
+			if value != tt.expectedValue {
+				t.Errorf("Find() value = %q, expected %q", value, tt.expectedValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds two useful utility methods to the `Slice` type to bring feature parity with `Set`:

## New Methods

### `Find(predicate func(T) bool) (T, bool)`
Returns the first element satisfying a predicate along with a boolean indicating if it was found. Returns the zero value of T and false if no element matches.

**Example:**
```go
numbers := Slice[int]{1, 3, 4, 5, 6}
even, found := numbers.Find(func(x int) bool { return x%2 == 0 })
// even = 4, found = true
```

### `None(predicate func(T) bool) bool`
Returns true if no elements satisfy the predicate. This is the logical inverse of `Any`. Returns true for empty slices.

**Example:**
```go
numbers := Slice[int]{1, 3, 5, 7}
hasEven := numbers.None(func(x int) bool { return x%2 == 0 })
// hasEven = true (no even numbers)
```

## Rationale

- **Consistency:** `Set` already has both `Find` and `None` methods
- **Ergonomics:** These are common operations when working with collections
- **Go idioms:** `Find` follows Go's pattern of returning (value, ok)

## Tests

Comprehensive tests added covering:
- Empty slice behavior
- Single element cases  
- Multiple matches (Find returns first)
- No matches
- Different types (int, string)
- Edge cases

All existing tests pass.