### PR TITLE
Add TakeWhile and DropWhile methods to Slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ func (a Slice[T]) Delete(element T) Slice[T]
 func (a Slice[T]) DeleteAt(index int) Slice[T]
 func (a Slice[T]) DeleteIf(block func(T) bool) Slice[T]
 func (a Slice[T]) Drop(count int) Slice[T]
+func (a Slice[T]) DropWhile(predicate func(T) bool) Slice[T]
 func (a Slice[T]) Each(block func(T))
 func (a Slice[T]) EachIndex(block func(int))
 func (a Slice[T]) Fetch(index int, defaultValue T) T
@@ -78,6 +79,7 @@ func (a Slice[T]) Select(block func(T) bool) Slice[T]
 func (a Slice[T]) SelectUntil(block func(T) bool) Slice[T]
 func (a Slice[T]) Shift() (T, Slice[T])
 func (a Slice[T]) Shuffle() Slice[T]
+func (a Slice[T]) TakeWhile(predicate func(T) bool) Slice[T]
 func (a Slice[T]) Unique() Slice[T]
 func (a Slice[T]) Unshift(element T) Slice[T]
 func SliceReduce[T comparable, U any](s Slice[T], initial U, fn func(U, T) U) U

--- a/slice.go
+++ b/slice.go
@@ -142,6 +142,29 @@ func (a Slice[T]) Drop(count int) Slice[T] {
 	return a[count:]
 }
 
+// TakeWhile returns a new slice containing elements from the start of the slice
+// while the predicate returns true. Stops at the first element where predicate returns false.
+func (a Slice[T]) TakeWhile(predicate func(T) bool) Slice[T] {
+	for i, elem := range a {
+		if !predicate(elem) {
+			return a[:i]
+		}
+	}
+	return a
+}
+
+// DropWhile returns a new slice with elements dropped from the start while the
+// predicate returns true. Returns the remaining elements starting from the first
+// element where predicate returns false.
+func (a Slice[T]) DropWhile(predicate func(T) bool) Slice[T] {
+	for i, elem := range a {
+		if !predicate(elem) {
+			return a[i:]
+		}
+	}
+	return Slice[T]{}
+}
+
 // Each will execute "block" for each element in array
 func (a Slice[T]) Each(block func(T)) {
 	for _, o := range a {

--- a/slice_takewhile_dropwhile_test.go
+++ b/slice_takewhile_dropwhile_test.go
@@ -1,0 +1,145 @@
+package types
+
+import (
+	"testing"
+)
+
+func TestSliceTakeWhile(t *testing.T) {
+	t.Run("takes elements while predicate is true", func(t *testing.T) {
+		s := Slice[int]{1, 2, 3, 4, 5, 6}
+		result := s.TakeWhile(func(x int) bool { return x < 4 })
+		expected := Slice[int]{1, 2, 3}
+		if !result.IsEq(expected) {
+			t.Errorf("TakeWhile: expected %v, got %v", expected, result)
+		}
+	})
+
+	t.Run("returns empty slice when first element fails predicate", func(t *testing.T) {
+		s := Slice[int]{5, 6, 7, 8}
+		result := s.TakeWhile(func(x int) bool { return x < 5 })
+		expected := Slice[int]{}
+		if !result.IsEq(expected) {
+			t.Errorf("TakeWhile: expected %v, got %v", expected, result)
+		}
+	})
+
+	t.Run("returns all elements when predicate always true", func(t *testing.T) {
+		s := Slice[int]{1, 2, 3, 4}
+		result := s.TakeWhile(func(x int) bool { return x < 10 })
+		if !result.IsEq(s) {
+			t.Errorf("TakeWhile: expected %v, got %v", s, result)
+		}
+	})
+
+	t.Run("returns empty slice for empty input", func(t *testing.T) {
+		s := Slice[int]{}
+		result := s.TakeWhile(func(x int) bool { return x < 5 })
+		expected := Slice[int]{}
+		if !result.IsEq(expected) {
+			t.Errorf("TakeWhile: expected %v, got %v", expected, result)
+		}
+	})
+
+	t.Run("works with strings", func(t *testing.T) {
+		s := Slice[string]{"apple", "banana", "cherry", "date"}
+		result := s.TakeWhile(func(x string) bool { return len(x) < 6 })
+		expected := Slice[string]{"apple"}
+		if !result.IsEq(expected) {
+			t.Errorf("TakeWhile: expected %v, got %v", expected, result)
+		}
+	})
+
+	t.Run("stops at first false predicate", func(t *testing.T) {
+		s := Slice[int]{2, 4, 6, 3, 8, 10}
+		result := s.TakeWhile(func(x int) bool { return x%2 == 0 })
+		expected := Slice[int]{2, 4, 6}
+		if !result.IsEq(expected) {
+			t.Errorf("TakeWhile: expected %v, got %v", expected, result)
+		}
+	})
+}
+
+func TestSliceDropWhile(t *testing.T) {
+	t.Run("drops elements while predicate is true", func(t *testing.T) {
+		s := Slice[int]{1, 2, 3, 4, 5, 6}
+		result := s.DropWhile(func(x int) bool { return x < 4 })
+		expected := Slice[int]{4, 5, 6}
+		if !result.IsEq(expected) {
+			t.Errorf("DropWhile: expected %v, got %v", expected, result)
+		}
+	})
+
+	t.Run("returns original slice when first element fails predicate", func(t *testing.T) {
+		s := Slice[int]{5, 6, 7, 8}
+		result := s.DropWhile(func(x int) bool { return x < 5 })
+		if !result.IsEq(s) {
+			t.Errorf("DropWhile: expected %v, got %v", s, result)
+		}
+	})
+
+	t.Run("returns empty slice when predicate always true", func(t *testing.T) {
+		s := Slice[int]{1, 2, 3, 4}
+		result := s.DropWhile(func(x int) bool { return x < 10 })
+		expected := Slice[int]{}
+		if !result.IsEq(expected) {
+			t.Errorf("DropWhile: expected %v, got %v", expected, result)
+		}
+	})
+
+	t.Run("returns empty slice for empty input", func(t *testing.T) {
+		s := Slice[int]{}
+		result := s.DropWhile(func(x int) bool { return x < 5 })
+		expected := Slice[int]{}
+		if !result.IsEq(expected) {
+			t.Errorf("DropWhile: expected %v, got %v", expected, result)
+		}
+	})
+
+	t.Run("works with strings", func(t *testing.T) {
+		s := Slice[string]{"apple", "banana", "cherry", "date"}
+		result := s.DropWhile(func(x string) bool { return len(x) < 6 })
+		expected := Slice[string]{"banana", "cherry", "date"}
+		if !result.IsEq(expected) {
+			t.Errorf("DropWhile: expected %v, got %v", expected, result)
+		}
+	})
+
+	t.Run("stops dropping at first false predicate", func(t *testing.T) {
+		s := Slice[int]{2, 4, 6, 3, 8, 10}
+		result := s.DropWhile(func(x int) bool { return x%2 == 0 })
+		expected := Slice[int]{3, 8, 10}
+		if !result.IsEq(expected) {
+			t.Errorf("DropWhile: expected %v, got %v", expected, result)
+		}
+	})
+}
+
+func TestTakeWhileDropWhileComplement(t *testing.T) {
+	t.Run("TakeWhile and DropWhile are complementary", func(t *testing.T) {
+		s := Slice[int]{1, 2, 3, 4, 5, 6, 7, 8}
+		predicate := func(x int) bool { return x < 5 }
+
+		taken := s.TakeWhile(predicate)
+		dropped := s.DropWhile(predicate)
+
+		// Concatenate taken and dropped should equal original
+		combined := append(taken, dropped...)
+
+		if !combined.IsEq(s) {
+			t.Errorf("TakeWhile and DropWhile should be complementary: expected %v, got %v", s, combined)
+		}
+	})
+
+	t.Run("lengths should sum to original length", func(t *testing.T) {
+		s := Slice[int]{10, 20, 30, 40, 50}
+		predicate := func(x int) bool { return x <= 30 }
+
+		taken := s.TakeWhile(predicate)
+		dropped := s.DropWhile(predicate)
+
+		if taken.Len()+dropped.Len() != s.Len() {
+			t.Errorf("Lengths don't match: taken %d + dropped %d != original %d",
+				taken.Len(), dropped.Len(), s.Len())
+		}
+	})
+}


### PR DESCRIPTION
This PR adds two commonly used Ruby-style collection methods to the Slice type:

## New Methods

### TakeWhile
Returns a new slice containing elements from the start while the predicate returns true. Stops at the first element where the predicate returns false.

**Example:**
```go
numbers := Slice[int]{1, 2, 3, 4, 5, 6}
result := numbers.TakeWhile(func(x int) bool { return x < 4 })
// result = [1, 2, 3]
```

### DropWhile
Returns a new slice with elements dropped from the start while the predicate returns true. Returns the remaining elements starting from the first element where the predicate returns false.

**Example:**
```go
numbers := Slice[int]{1, 2, 3, 4, 5, 6}
result := numbers.DropWhile(func(x int) bool { return x < 4 })
// result = [4, 5, 6]
```

## Use Cases

These methods are particularly useful for:
- Processing data streams until a condition is met
- Splitting sequences based on dynamic conditions
- More expressive than index-based slicing when the split point depends on element values

For example, parsing input lines:
```go
lines := Slice[string]{"header1", "header2", "", "data1", "data2"}
headers := lines.TakeWhile(func(s string) bool { return s != "" })
data := lines.DropWhile(func(s string) bool { return s != "" }).Drop(1)
```

## Complementary Behavior

`TakeWhile` and `DropWhile` are complementary - concatenating their results reconstructs the original slice:
```go
taken := slice.TakeWhile(predicate)
dropped := slice.DropWhile(predicate)
reconstructed := append(taken, dropped...) // equals original slice
```

## Testing

Comprehensive tests included covering:
- ✅ Empty slices
- ✅ Predicate always true
- ✅ Predicate always false
- ✅ First element failing predicate
- ✅ String type operations
- ✅ Complementary behavior verification
- ✅ Edge cases

All tests pass:
```
=== RUN   TestSliceTakeWhile
=== RUN   TestSliceDropWhile
=== RUN   TestTakeWhileDropWhileComplement
--- PASS: TestSliceTakeWhile (0.00s)
--- PASS: TestSliceDropWhile (0.00s)
--- PASS: TestTakeWhileDropWhileComplement (0.00s)
```

## Documentation

README.md has been updated to include the new methods in the Slice methods list.