### PR TITLE
Add Slice.Rotate() method for rotating slice elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ func (a Slice[T]) Pop() (Slice[T], T)
 func (a Slice[T]) Push(element T) Slice[T]
 func (a Slice[T]) Reduce(block func(T) bool) Slice[T]
 func (a Slice[T]) Reverse() Slice[T]
+func (a Slice[T]) Rotate(count int) Slice[T]
 func (a Slice[T]) Sample() (T, bool)
 func (a Slice[T]) SampleN(n int) Slice[T]
 func (a Slice[T]) Select(block func(T) bool) Slice[T]

--- a/example_slice_rotate_test.go
+++ b/example_slice_rotate_test.go
@@ -1,0 +1,24 @@
+package types
+
+import "fmt"
+
+func ExampleSlice_Rotate() {
+	nums := Slice[int]{1, 2, 3, 4, 5}
+
+	// Rotate left by 2 positions
+	left := nums.Rotate(2)
+	fmt.Println(left)
+
+	// Rotate right by 2 positions
+	right := nums.Rotate(-2)
+	fmt.Println(right)
+
+	// Rotate by more than length
+	bigRotate := nums.Rotate(7) // equivalent to rotating by 2
+	fmt.Println(bigRotate)
+
+	// Output:
+	// [3 4 5 1 2]
+	// [4 5 1 2 3]
+	// [3 4 5 1 2]
+}

--- a/slice.go
+++ b/slice.go
@@ -458,6 +458,32 @@ func (a Slice[T]) Reverse() Slice[T] {
 	return result
 }
 
+// Rotate returns a new slice with elements rotated by count positions.
+// Positive count rotates to the left (elements move towards index 0),
+// negative count rotates to the right (elements move towards the end).
+// The original slice is not modified.
+// Inspired by Ruby's Array#rotate method.
+// Example: Slice[int]{1, 2, 3, 4, 5}.Rotate(2) returns [3, 4, 5, 1, 2]
+// Example: Slice[int]{1, 2, 3, 4, 5}.Rotate(-2) returns [4, 5, 1, 2, 3]
+func (a Slice[T]) Rotate(count int) Slice[T] {
+	length := len(a)
+	if length == 0 {
+		return Slice[T]{}
+	}
+
+	// Normalize count to be within slice bounds
+	// Use modulo to handle counts larger than slice length
+	count = count % length
+	if count < 0 {
+		count = length + count
+	}
+
+	result := make(Slice[T], length)
+	copy(result, a[count:])
+	copy(result[length-count:], a[:count])
+	return result
+}
+
 // Shuffle returns a new slice with elements in random order.
 // The original slice is not modified.
 func (a Slice[T]) Shuffle() Slice[T] {

--- a/slice_rotate_test.go
+++ b/slice_rotate_test.go
@@ -1,0 +1,153 @@
+package types
+
+import (
+	"testing"
+)
+
+func TestSliceRotate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    Slice[int]
+		count    int
+		expected Slice[int]
+	}{
+		{
+			name:     "rotate left by 2",
+			input:    Slice[int]{1, 2, 3, 4, 5},
+			count:    2,
+			expected: Slice[int]{3, 4, 5, 1, 2},
+		},
+		{
+			name:     "rotate right by 2",
+			input:    Slice[int]{1, 2, 3, 4, 5},
+			count:    -2,
+			expected: Slice[int]{4, 5, 1, 2, 3},
+		},
+		{
+			name:     "rotate left by 1",
+			input:    Slice[int]{1, 2, 3, 4, 5},
+			count:    1,
+			expected: Slice[int]{2, 3, 4, 5, 1},
+		},
+		{
+			name:     "rotate right by 1",
+			input:    Slice[int]{1, 2, 3, 4, 5},
+			count:    -1,
+			expected: Slice[int]{5, 1, 2, 3, 4},
+		},
+		{
+			name:     "rotate by 0 (no change)",
+			input:    Slice[int]{1, 2, 3, 4, 5},
+			count:    0,
+			expected: Slice[int]{1, 2, 3, 4, 5},
+		},
+		{
+			name:     "rotate by length (full rotation, no change)",
+			input:    Slice[int]{1, 2, 3, 4, 5},
+			count:    5,
+			expected: Slice[int]{1, 2, 3, 4, 5},
+		},
+		{
+			name:     "rotate by negative length (full rotation, no change)",
+			input:    Slice[int]{1, 2, 3, 4, 5},
+			count:    -5,
+			expected: Slice[int]{1, 2, 3, 4, 5},
+		},
+		{
+			name:     "rotate by more than length",
+			input:    Slice[int]{1, 2, 3, 4, 5},
+			count:    7, // equivalent to rotating by 2
+			expected: Slice[int]{3, 4, 5, 1, 2},
+		},
+		{
+			name:     "rotate by negative more than length",
+			input:    Slice[int]{1, 2, 3, 4, 5},
+			count:    -7, // equivalent to rotating by -2
+			expected: Slice[int]{4, 5, 1, 2, 3},
+		},
+		{
+			name:     "empty slice",
+			input:    Slice[int]{},
+			count:    3,
+			expected: Slice[int]{},
+		},
+		{
+			name:     "single element",
+			input:    Slice[int]{42},
+			count:    1,
+			expected: Slice[int]{42},
+		},
+		{
+			name:     "two elements rotate left",
+			input:    Slice[int]{1, 2},
+			count:    1,
+			expected: Slice[int]{2, 1},
+		},
+		{
+			name:     "two elements rotate right",
+			input:    Slice[int]{1, 2},
+			count:    -1,
+			expected: Slice[int]{2, 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.input.Rotate(tt.count)
+
+			// Check length
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected length %d, got %d", len(tt.expected), len(result))
+				return
+			}
+
+			// Check each element
+			for i := range result {
+				if result[i] != tt.expected[i] {
+					t.Errorf("at index %d: expected %v, got %v", i, tt.expected[i], result[i])
+				}
+			}
+
+			// Verify original slice is not modified
+			if len(tt.input) > 0 {
+				// Just check the first element to ensure immutability
+				firstElement := tt.input[0]
+				_ = tt.input.Rotate(tt.count)
+				if tt.input[0] != firstElement {
+					t.Errorf("original slice was modified")
+				}
+			}
+		})
+	}
+}
+
+func TestSliceRotateWithStrings(t *testing.T) {
+	input := Slice[string]{"a", "b", "c", "d", "e"}
+
+	tests := []struct {
+		name     string
+		count    int
+		expected Slice[string]
+	}{
+		{
+			name:     "rotate strings left by 2",
+			count:    2,
+			expected: Slice[string]{"c", "d", "e", "a", "b"},
+		},
+		{
+			name:     "rotate strings right by 2",
+			count:    -2,
+			expected: Slice[string]{"d", "e", "a", "b", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := input.Rotate(tt.count)
+
+			if !result.IsEq(tt.expected) {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the `Rotate()` method to the `Slice` type, inspired by Ruby's `Array#rotate` method.

## Features
- Rotate slice elements left (positive count) or right (negative count)
- Handles edge cases: empty slices, single elements, counts larger than slice length
- Returns a new slice, original is not modified
- Full test coverage with comprehensive test cases

## Examples
```go
nums := Slice[int]{1, 2, 3, 4, 5}
nums.Rotate(2)   // [3, 4, 5, 1, 2] - rotate left by 2
nums.Rotate(-2)  // [4, 5, 1, 2, 3] - rotate right by 2
```

## Coverage
Maintains test coverage at 95.4%