### PR TITLE
Add Flatten function for flattening nested slices

### DIFF
--- a/example_slice_flatten_test.go
+++ b/example_slice_flatten_test.go
@@ -1,0 +1,44 @@
+package types
+
+import "fmt"
+
+func ExampleFlatten() {
+	nested := [][]int{
+		{1, 2, 3},
+		{4, 5},
+		{6, 7, 8, 9},
+	}
+
+	flat := Flatten(nested)
+	fmt.Println(flat)
+
+	// Output: [1 2 3 4 5 6 7 8 9]
+}
+
+func ExampleFlatten_strings() {
+	words := [][]string{
+		{"hello", "world"},
+		{"foo", "bar"},
+		{"baz"},
+	}
+
+	result := Flatten(words)
+	fmt.Println(result)
+
+	// Output: [hello world foo bar baz]
+}
+
+func ExampleFlatten_withEmptySlices() {
+	nested := [][]int{
+		{1, 2},
+		{},
+		{3, 4},
+		{},
+		{5},
+	}
+
+	flat := Flatten(nested)
+	fmt.Println(flat)
+
+	// Output: [1 2 3 4 5]
+}

--- a/slice.go
+++ b/slice.go
@@ -539,6 +539,17 @@ func (a Slice[T]) Unique() Slice[T] {
 	return out
 }
 
+// Flatten converts a slice of slices into a single-level slice by concatenating all nested slices.
+// This is inspired by Ruby's Array#flatten method (depth=1).
+// Example: Flatten(Slice[Slice[int]]{{1, 2}, {3, 4}, {5}}) returns Slice[int]{1, 2, 3, 4, 5}
+func Flatten[T any](a [][]T) []T {
+	result := []T{}
+	for _, nested := range a {
+		result = append(result, nested...)
+	}
+	return result
+}
+
 // Partition divides the slice into two new slices based on the predicate function.
 // Returns two slices: the first contains elements that satisfy the predicate,
 // the second contains elements that do not satisfy the predicate.

--- a/slice_flatten_test.go
+++ b/slice_flatten_test.go
@@ -1,0 +1,87 @@
+package types
+
+import (
+	"testing"
+)
+
+func TestFlatten(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    [][]int
+		expected []int
+	}{
+		{
+			name:     "basic flatten",
+			input:    [][]int{{1, 2}, {3, 4}, {5}},
+			expected: []int{1, 2, 3, 4, 5},
+		},
+		{
+			name:     "empty nested slices",
+			input:    [][]int{{}, {1, 2}, {}, {3}},
+			expected: []int{1, 2, 3},
+		},
+		{
+			name:     "single nested slice",
+			input:    [][]int{{1, 2, 3}},
+			expected: []int{1, 2, 3},
+		},
+		{
+			name:     "empty outer slice",
+			input:    [][]int{},
+			expected: []int{},
+		},
+		{
+			name:     "all empty nested slices",
+			input:    [][]int{{}, {}, {}},
+			expected: []int{},
+		},
+		{
+			name:     "single elements in nested slices",
+			input:    [][]int{{1}, {2}, {3}},
+			expected: []int{1, 2, 3},
+		},
+		{
+			name:     "varying lengths",
+			input:    [][]int{{1}, {2, 3, 4}, {5, 6}},
+			expected: []int{1, 2, 3, 4, 5, 6},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Flatten(tt.input)
+			if !Slice[int](result).IsEq(Slice[int](tt.expected)) {
+				t.Errorf("Flatten() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFlattenStrings(t *testing.T) {
+	input := [][]string{
+		{"hello", "world"},
+		{"foo", "bar"},
+		{"baz"},
+	}
+	expected := []string{"hello", "world", "foo", "bar", "baz"}
+	result := Flatten(input)
+
+	if !Slice[string](result).IsEq(Slice[string](expected)) {
+		t.Errorf("Flatten() = %v, want %v", result, expected)
+	}
+}
+
+func TestFlattenPreservesOrder(t *testing.T) {
+	input := [][]int{
+		{9, 8, 7},
+		{6, 5},
+		{4, 3, 2, 1},
+	}
+	expected := []int{9, 8, 7, 6, 5, 4, 3, 2, 1}
+	result := Flatten(input)
+
+	if !Slice[int](result).IsEq(Slice[int](expected)) {
+		t.Errorf("Flatten() should preserve order: got %v, want %v", result, expected)
+	}
+}
+


### PR DESCRIPTION
Adds a new `Flatten[T]([][]T)` function inspired by Ruby's `Array#flatten` method.

## Changes
- Implements `Flatten` function to concatenate nested slices into a single-level slice
- Supports any type (uses `any` constraint instead of `comparable`)
- Preserves order of elements from nested slices

## Tests
- Comprehensive test coverage for various scenarios (empty slices, varying lengths, order preservation)
- Example documentation for different use cases

## Example Usage
```go
nested := [][]int{{1, 2}, {3, 4}, {5}}
flat := Flatten(nested)
// Returns: []int{1, 2, 3, 4, 5}
```

This complements the existing Ruby-inspired slice methods in the types package.