### PR TITLE
Add Map constructors: NewMapFrom and Entries methods

### DIFF
--- a/map.go
+++ b/map.go
@@ -8,6 +8,16 @@ type Map[K comparable, V any] struct {
 	store sync.Map
 }
 
+// NewMapFrom creates a new Map initialized with entries from a regular Go map.
+// This provides a convenient way to convert from map[K]V to *Map[K, V].
+func NewMapFrom[K comparable, V any](m map[K]V) *Map[K, V] {
+	result := &Map[K, V]{}
+	for k, v := range m {
+		result.Store(k, v)
+	}
+	return result
+}
+
 func (m *Map[K, V]) Store(k K, v V) {
 	m.store.Store(k, v)
 }
@@ -143,6 +153,18 @@ func (m *Map[K, V]) Transform(transformer func(k K, v V) V) *Map[K, V] {
 		key := k.(K)
 		value := v.(V)
 		result.Store(key, transformer(key, value))
+		return true
+	})
+	return result
+}
+
+// Entries returns a regular Go map containing all key-value pairs from the Map.
+// This provides a convenient way to convert from *Map[K, V] to map[K]V.
+// The order of entries is not guaranteed.
+func (m *Map[K, V]) Entries() map[K]V {
+	result := make(map[K]V)
+	m.store.Range(func(k, v any) bool {
+		result[k.(K)] = v.(V)
 		return true
 	})
 	return result

--- a/map_test.go
+++ b/map_test.go
@@ -304,4 +304,90 @@ func TestMap(t *testing.T) {
 			t.Errorf("Expected transformed empty map, got size %d", transformed.Size())
 		}
 	})
+
+	t.Run("NewMapFrom", func(t *testing.T) {
+		source := map[string]int{
+			"a": 1,
+			"b": 2,
+			"c": 3,
+		}
+
+		m := NewMapFrom(source)
+
+		if m.Size() != 3 {
+			t.Errorf("Expected size 3, got %d", m.Size())
+		}
+
+		if v, ok := m.Load("a"); !ok || v != 1 {
+			t.Errorf("Expected a=1, got %d", v)
+		}
+		if v, ok := m.Load("b"); !ok || v != 2 {
+			t.Errorf("Expected b=2, got %d", v)
+		}
+		if v, ok := m.Load("c"); !ok || v != 3 {
+			t.Errorf("Expected c=3, got %d", v)
+		}
+	})
+
+	t.Run("NewMapFrom empty map", func(t *testing.T) {
+		source := map[string]int{}
+		m := NewMapFrom(source)
+
+		if m.Size() != 0 {
+			t.Errorf("Expected size 0 for empty map, got %d", m.Size())
+		}
+	})
+
+	t.Run("Entries", func(t *testing.T) {
+		m := Map[string, int]{}
+		m.Store("a", 1)
+		m.Store("b", 2)
+		m.Store("c", 3)
+
+		entries := m.Entries()
+
+		if len(entries) != 3 {
+			t.Errorf("Expected 3 entries, got %d", len(entries))
+		}
+
+		if entries["a"] != 1 {
+			t.Errorf("Expected a=1, got %d", entries["a"])
+		}
+		if entries["b"] != 2 {
+			t.Errorf("Expected b=2, got %d", entries["b"])
+		}
+		if entries["c"] != 3 {
+			t.Errorf("Expected c=3, got %d", entries["c"])
+		}
+	})
+
+	t.Run("Entries empty map", func(t *testing.T) {
+		m := Map[string, int]{}
+		entries := m.Entries()
+
+		if len(entries) != 0 {
+			t.Errorf("Expected 0 entries for empty map, got %d", len(entries))
+		}
+	})
+
+	t.Run("NewMapFrom and Entries roundtrip", func(t *testing.T) {
+		original := map[string]int{
+			"x": 10,
+			"y": 20,
+			"z": 30,
+		}
+
+		m := NewMapFrom(original)
+		result := m.Entries()
+
+		if len(result) != len(original) {
+			t.Errorf("Expected %d entries, got %d", len(original), len(result))
+		}
+
+		for k, v := range original {
+			if result[k] != v {
+				t.Errorf("Expected %s=%d, got %d", k, v, result[k])
+			}
+		}
+	})
 }


### PR DESCRIPTION
This PR adds convenient constructors for the Map type:

- **NewMapFrom(map[K]V)** - Creates a *Map[K,V] from a regular Go map
- **Entries()** - Converts *Map[K,V] back to map[K]V

These methods enable easy conversion between the concurrent-safe Map type and standard Go maps, making it more convenient to:
- Initialize Maps from existing data structures
- Export Map data for use with standard library functions
- Test Map behavior with familiar map[K]V syntax

All changes include comprehensive tests with roundtrip verification.