### PR TITLE
feat: Add Slice.Duplicates method

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -607,6 +607,28 @@ func (a Slice[T]) Tally() map[T]int {
 	return result
 }
 
+// Duplicates returns a new slice containing elements that appear more than once in the original slice.
+// Each duplicate element appears only once in the result. The order is based on first appearance.
+// Example: Slice[int]{1, 2, 2, 3, 1, 4}.Duplicates() returns Slice[int]{1, 2}
+func (a Slice[T]) Duplicates() Slice[T] {
+	counts := make(map[T]int)
+	for _, element := range a {
+		counts[element]++
+	}
+
+	duplicates := Slice[T]{}
+	seen := make(map[T]struct{})
+	for _, element := range a {
+		if counts[element] > 1 {
+			if _, exists := seen[element]; !exists {
+				duplicates = append(duplicates, element)
+				seen[element] = struct{}{}
+			}
+		}
+	}
+	return duplicates
+}
+
 // Zip combines this slice with another slice element-wise, creating pairs.
 // Returns a slice of pairs (2-element arrays) where each pair contains
 // one element from this slice and one from the other slice at the same index.

--- a/slice_duplicates_test.go
+++ b/slice_duplicates_test.go
@@ -1,0 +1,27 @@
+package types
+
+import "testing"
+
+func TestSliceDuplicates(t *testing.T) {
+	tests := []struct {
+		name  string
+		slice Slice[int]
+		want  Slice[int]
+	}{
+		{"no duplicates", Slice[int]{1, 2, 3, 4}, Slice[int]{}},
+		{"one duplicate pair", Slice[int]{1, 2, 2, 3}, Slice[int]{2}},
+		{"multiple duplicate pairs", Slice[int]{1, 2, 2, 3, 3}, Slice[int]{2, 3}},
+		{"multiple occurrences", Slice[int]{1, 1, 1, 2, 2}, Slice[int]{1, 2}},
+		{"empty slice", Slice[int]{}, Slice[int]{}},
+		{"all unique", Slice[int]{5, 6, 7}, Slice[int]{}},
+		{"interspersed duplicates", Slice[int]{1, 2, 1, 3, 2}, Slice[int]{1, 2}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.slice.Duplicates(); !got.IsEq(tt.want) {
+				t.Errorf("Slice.Duplicates() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a new 'Duplicates' method to the 'Slice' type, which returns a new slice containing elements that appear more than once in the original slice.

Each duplicate element appears only once in the result, with the order determined by the first appearance of the duplicate in the original slice.

Example:
```go
s := types.Slice[int]{1, 2, 2, 3, 1, 4}
duplicates := s.Duplicates() // returns types.Slice[int]{1, 2}
```