### PR TITLE
feat: Add Slice.Reject method

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -353,6 +353,18 @@ func (a Slice[T]) Select(block func(T) bool) Slice[T] {
 	return a.KeepIf(block)
 }
 
+// Reject returns a new slice containing elements for which the block returns false.
+// It is the logical opposite of Select (or KeepIf).
+func (a Slice[T]) Reject(block func(T) bool) Slice[T] {
+	result := Slice[T]{}
+	for _, o := range a {
+		if !block(o) {
+			result = append(result, o)
+		}
+	}
+	return result
+}
+
 // SelectUntil selects from the start of the slice until the block returns true,
 // excluding the item that returned true.
 func (a Slice[T]) SelectUntil(block func(T) bool) Slice[T] {

--- a/slice_reject_test.go
+++ b/slice_reject_test.go
@@ -1,0 +1,16 @@
+package types
+
+import "testing"
+
+func TestSliceReject(t *testing.T) {
+	s := Slice[int]{1, 2, 3, 4, 5, 6}
+	
+	rejected := s.Reject(func(i int) bool {
+		return i%2 == 0
+	})
+
+	expected := Slice[int]{1, 3, 5}
+	if !rejected.IsEq(expected) {
+		t.Errorf("Expected %v but got %v", expected, rejected)
+	}
+}


### PR DESCRIPTION
This adds the 'Reject' method to the 'Slice' type. 'Reject' is the logical opposite of 'Select' (or 'KeepIf'), returning a new slice containing all elements for which the provided block returns 'false'.