### PR TITLE
Add comprehensive tests for Slice.Insert method

### DIFF
--- a/slice_test.go
+++ b/slice_test.go
@@ -3060,3 +3060,141 @@ func TestSliceFillWithEmptySlice(t *testing.T) {
 	expected := Slice[int]{}
 	AssertSlicesEquals(t, result, expected)
 }
+
+func TestSliceInsert(t *testing.T) {
+	tests := []struct {
+		name     string
+		slice    Slice[int]
+		index    int
+		elements []int
+		want     Slice[int]
+	}{
+		{
+			name:     "insert at beginning",
+			slice:    Slice[int]{3, 4, 5},
+			index:    0,
+			elements: []int{1, 2},
+			want:     Slice[int]{1, 2, 3, 4, 5},
+		},
+		{
+			name:     "insert at end",
+			slice:    Slice[int]{1, 2, 3},
+			index:    3,
+			elements: []int{4, 5},
+			want:     Slice[int]{1, 2, 3, 4, 5},
+		},
+		{
+			name:     "insert in middle",
+			slice:    Slice[int]{1, 2, 5, 6},
+			index:    2,
+			elements: []int{3, 4},
+			want:     Slice[int]{1, 2, 3, 4, 5, 6},
+		},
+		{
+			name:     "insert single element at beginning",
+			slice:    Slice[int]{2, 3, 4},
+			index:    0,
+			elements: []int{1},
+			want:     Slice[int]{1, 2, 3, 4},
+		},
+		{
+			name:     "insert single element in middle",
+			slice:    Slice[int]{1, 3, 4},
+			index:    1,
+			elements: []int{2},
+			want:     Slice[int]{1, 2, 3, 4},
+		},
+		{
+			name:     "insert single element at end",
+			slice:    Slice[int]{1, 2, 3},
+			index:    3,
+			elements: []int{4},
+			want:     Slice[int]{1, 2, 3, 4},
+		},
+		{
+			name:     "insert into empty slice",
+			slice:    Slice[int]{},
+			index:    0,
+			elements: []int{1, 2, 3},
+			want:     Slice[int]{1, 2, 3},
+		},
+		{
+			name:     "insert empty elements",
+			slice:    Slice[int]{1, 2, 3},
+			index:    1,
+			elements: []int{},
+			want:     Slice[int]{1, 2, 3},
+		},
+		{
+			name:     "insert multiple elements at beginning",
+			slice:    Slice[int]{4, 5},
+			index:    0,
+			elements: []int{1, 2, 3},
+			want:     Slice[int]{1, 2, 3, 4, 5},
+		},
+		{
+			name:     "insert multiple elements at end",
+			slice:    Slice[int]{1, 2},
+			index:    2,
+			elements: []int{3, 4, 5},
+			want:     Slice[int]{1, 2, 3, 4, 5},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.slice.Insert(tt.index, tt.elements...)
+			AssertSlicesEquals(t, got, tt.want)
+		})
+	}
+}
+
+func TestSliceInsertWithStrings(t *testing.T) {
+	tests := []struct {
+		name     string
+		slice    Slice[string]
+		index    int
+		elements []string
+		want     Slice[string]
+	}{
+		{
+			name:     "insert string at beginning",
+			slice:    Slice[string]{"world"},
+			index:    0,
+			elements: []string{"hello"},
+			want:     Slice[string]{"hello", "world"},
+		},
+		{
+			name:     "insert multiple strings in middle",
+			slice:    Slice[string]{"a", "d"},
+			index:    1,
+			elements: []string{"b", "c"},
+			want:     Slice[string]{"a", "b", "c", "d"},
+		},
+		{
+			name:     "insert empty string",
+			slice:    Slice[string]{"a", "b"},
+			index:    1,
+			elements: []string{""},
+			want:     Slice[string]{"a", "", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.slice.Insert(tt.index, tt.elements...)
+			AssertSlicesEquals(t, got, tt.want)
+		})
+	}
+}
+
+func TestSliceInsertImmutability(t *testing.T) {
+	original := Slice[int]{1, 2, 3}
+	originalCopy := make(Slice[int], len(original))
+	copy(originalCopy, original)
+
+	result := original.Insert(1, 99)
+
+	AssertSlicesEquals(t, original, originalCopy)
+	AssertSlicesEquals(t, result, Slice[int]{1, 99, 2, 3})
+}


### PR DESCRIPTION
This PR adds comprehensive test coverage for the `Slice.Insert` method, which previously had 0% test coverage.

**Changes:**
- Added 10 test cases for integer slices covering various insertion scenarios
- Added 3 test cases for string slices
- Added immutability verification test
- Tests cover: insertion at beginning, middle, and end; empty slices; empty elements; single and multiple elements

**Impact:**
- Increases overall test coverage from 91.5% to 92.2%
- `Insert` method now has 100% test coverage
- All tests passing

**Test scenarios covered:**
✅ Insert at beginning, middle, and end positions
✅ Insert single and multiple elements
✅ Insert into empty slice
✅ Insert empty elements (no-op)
✅ Verify immutability of original slice
✅ Works with different types (int, string)