### PR TITLE
Add comprehensive tests for IsEq method

### DIFF
--- a/slice_test.go
+++ b/slice_test.go
@@ -3477,3 +3477,64 @@ func TestSliceSelect(t *testing.T) {
 		}
 	})
 }
+
+func TestIsEq(t *testing.T) {
+	tests := []struct {
+		name     string
+		slice    Slice[int]
+		other    Slice[int]
+		expected bool
+	}{
+		{
+			name:     "equal slices",
+			slice:    Slice[int]{1, 2, 3},
+			other:    Slice[int]{1, 2, 3},
+			expected: true,
+		},
+		{
+			name:     "different lengths",
+			slice:    Slice[int]{1, 2, 3},
+			other:    Slice[int]{1, 2},
+			expected: false,
+		},
+		{
+			name:     "same length different values",
+			slice:    Slice[int]{1, 2, 3},
+			other:    Slice[int]{1, 2, 4},
+			expected: false,
+		},
+		{
+			name:     "both empty",
+			slice:    Slice[int]{},
+			other:    Slice[int]{},
+			expected: true,
+		},
+		{
+			name:     "one empty one not",
+			slice:    Slice[int]{1},
+			other:    Slice[int]{},
+			expected: false,
+		},
+		{
+			name:     "different values at start",
+			slice:    Slice[int]{5, 2, 3},
+			other:    Slice[int]{1, 2, 3},
+			expected: false,
+		},
+		{
+			name:     "different values at middle",
+			slice:    Slice[int]{1, 5, 3},
+			other:    Slice[int]{1, 2, 3},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.slice.IsEq(tt.other)
+			if result != tt.expected {
+				t.Errorf("IsEq() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Improved test coverage for the `IsEq` method from 66.7% to 100%.

## Changes
- Added dedicated test suite for `IsEq` with 7 test cases
- Covers edge cases: equal slices, different lengths, different values, empty slices
- Overall project coverage improved from 96.5% to 96.8%

## Testing
All tests pass (`go test -v -run TestIsEq`)